### PR TITLE
Fix square viewer sizing

### DIFF
--- a/src/components/shape-viewer.tsx
+++ b/src/components/shape-viewer.tsx
@@ -97,7 +97,7 @@ export default function ShapeViewer({
   }, [])
 
   const x3dContent = `
-    <x3d width="600px" height="600px" style="width: 100%; height: 100%; display: block;">
+    <x3d style="width: 100%; height: 100%; display: block;">
       <scene>
         <viewpoint position="0 0 ${cameraDistance}" orientation="0 1 0 0" fieldofview="${fieldOfView}"></viewpoint>
         ${faces

--- a/src/components/shape-viewer.tsx
+++ b/src/components/shape-viewer.tsx
@@ -97,7 +97,7 @@ export default function ShapeViewer({
   }, [])
 
   const x3dContent = `
-    <x3d width="100%" height="100%" style="width: 100%; height: 100%; display: block;">
+    <x3d style="width: 100%; height: 100%; display: block;">
       <scene>
         <viewpoint position="0 0 ${cameraDistance}" orientation="0 1 0 0" fieldofview="${fieldOfView}"></viewpoint>
         ${faces

--- a/src/components/shape-viewer.tsx
+++ b/src/components/shape-viewer.tsx
@@ -137,6 +137,7 @@ export default function ShapeViewer({
       <div
         ref={containerRef}
         className='bg-background border border-border rounded-lg overflow-hidden'
+        style={{ width: 'min(100%, calc(100vh - 2rem))', aspectRatio: '1 / 1' }}
         dangerouslySetInnerHTML={{ __html: x3dContent }}
       />
     </div>

--- a/src/components/shape-viewer.tsx
+++ b/src/components/shape-viewer.tsx
@@ -97,7 +97,7 @@ export default function ShapeViewer({
   }, [])
 
   const x3dContent = `
-    <x3d style="width: 100%; height: 100%; display: block;">
+    <x3d width="100%" height="100%" style="width: 100%; height: 100%; display: block;">
       <scene>
         <viewpoint position="0 0 ${cameraDistance}" orientation="0 1 0 0" fieldofview="${fieldOfView}"></viewpoint>
         ${faces


### PR DESCRIPTION
## Summary
- ensure the X3D scene fills available space while staying square

## Testing
- `pnpm lint`
- `pnpm types`


------
https://chatgpt.com/codex/tasks/task_e_685750ad4a308321a026a1062c90faf3