### PR TITLE
Fix sidebar position and viewer resize

### DIFF
--- a/src/app/[shape]/page.tsx
+++ b/src/app/[shape]/page.tsx
@@ -29,7 +29,6 @@ export default async function PolyhedronPage({ params }: PageProps) {
       <div className='w-full h-screen'>
         <ShapeViewer
           key={resolvedParams.shape}
-          shapeName={resolvedParams.shape}
           vertices={data!.vertices}
           faces={data!.faces}
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -192,7 +192,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-hidden;
     letter-spacing: var(--tracking-normal);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
       <body>
         <ThemeProvider>
           <div className='flex h-screen'>
-            <div className='flex-1 ml-[25%]'>{children}</div>
+            <div className='flex-1 mr-[25%]'>{children}</div>
           </div>
         </ThemeProvider>
         <Script src='/vendor/x3dom.js' strategy='beforeInteractive' />

--- a/src/components/shape-sidebar.tsx
+++ b/src/components/shape-sidebar.tsx
@@ -27,7 +27,7 @@ export default function ShapeSidebar({ shapes }: ShapeSidebarProps) {
   }
 
   return (
-    <aside className='fixed left-0 top-0 h-full w-1/4 border-r border-border bg-background p-4'>
+    <aside className='fixed right-0 top-0 h-full w-1/4 border-l border-border bg-background p-4'>
       <Select value={currentShape} onValueChange={handleShapeChange}>
         <SelectTrigger className='w-full'>
           <SelectValue placeholder='Select a shape'>


### PR DESCRIPTION
## Summary
- move sidebar to the right and adjust layout
- hide page scrollbars
- avoid reloading X3DOM viewer on resize

## Testing
- `npm run lint`
- `npm run types`


------
https://chatgpt.com/codex/tasks/task_e_6858232379688321b4535d80e9a4c205