### PR TITLE
Fix x3dom resize reload

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
         />
         <link rel='stylesheet' href='/vendor/x3dom.css' />
       </head>
-      <body>
+      <body className='overflow-hidden'>
         <ThemeProvider>
           <div className='flex h-screen'>
             <div className='flex-1 ml-[25%]'>{children}</div>

--- a/src/types/x3dom-global.d.ts
+++ b/src/types/x3dom-global.d.ts
@@ -19,6 +19,8 @@ declare module 'react' {
       > & {
         is?: string
         style?: React.CSSProperties
+        width?: string
+        height?: string
       }
       scene: React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLElement>,


### PR DESCRIPTION
## Summary
- prevent layout overflow
- render x3d elements directly so the scene resizes without reloading
- extend x3d types

## Testing
- `npm run format`
- `npm run types`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_685825ed0738832197c88ef5640935d0