### PR TITLE
Smooth scene resize with x3dom runtime

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
       <body>
         <ThemeProvider>
           <div className='flex h-screen'>
-            <div className='flex-1 ml-[25%]'>{children}</div>
+            <div className='ml-[25%] w-3/4 h-screen'>{children}</div>
           </div>
         </ThemeProvider>
         <Script src='/vendor/x3dom.js' strategy='beforeInteractive' />

--- a/src/components/shape-viewer.tsx
+++ b/src/components/shape-viewer.tsx
@@ -19,6 +19,9 @@ export default function ShapeViewer({
 }: ShapeViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const parentRef = useRef<HTMLDivElement>(null)
+  interface X3DElement extends HTMLElement {
+    runtime?: { resize?: () => void }
+  }
   const [foregroundColor, setForegroundColor] = useState('1 1 1')
   const [cameraDistance, setCameraDistance] = useState(0)
   const [dimensions, setDimensions] = useState({ width: 600, height: 600 })
@@ -91,87 +94,89 @@ export default function ShapeViewer({
 
   useEffect(() => {
     updateCameraDistance()
-    if (containerRef.current && window.x3dom) {
-      window.x3dom.reload()
-      updateCameraDistance()
 
-      const computedStyle = getComputedStyle(document.documentElement)
-      const foreground = computedStyle.getPropertyValue('--foreground').trim()
+    const computedStyle = getComputedStyle(document.documentElement)
+    const foreground = computedStyle.getPropertyValue('--foreground').trim()
 
-      if (foreground) {
-        const tempDiv = document.createElement('div')
-        tempDiv.style.color = `oklch(${foreground})`
-        document.body.appendChild(tempDiv)
-        const rgbColor = getComputedStyle(tempDiv).color
-        document.body.removeChild(tempDiv)
+    if (foreground) {
+      const tempDiv = document.createElement('div')
+      tempDiv.style.color = `oklch(${foreground})`
+      document.body.appendChild(tempDiv)
+      const rgbColor = getComputedStyle(tempDiv).color
+      document.body.removeChild(tempDiv)
 
-        setForegroundColor(rgbToX3d(rgbColor))
-      }
+      setForegroundColor(rgbToX3d(rgbColor))
     }
+
     window.addEventListener('resize', updateCameraDistance)
     return () => window.removeEventListener('resize', updateCameraDistance)
   }, [updateCameraDistance])
 
-  const x3dContent = useMemo(
-    () => `
-    <x3d width="${dimensions.width}px" height="${dimensions.height}px" style="width: 100%; height: 100%; display: block;">
-      <scene>
-        <viewpoint position="0 0 ${cameraDistance}" orientation="0 1 0 0" fieldofview="${fieldOfView}"></viewpoint>
-        ${faces
-          .map(face => {
-            const center = calculateFaceCenter(face)
-            const faceCoordinates = face
-              .map(vertexIndex => {
-                const vertex = vertices[vertexIndex]
-                const scaledVertex = [
-                  center[0] + (vertex[0] - center[0]) * scaleFactor,
-                  center[1] + (vertex[1] - center[1]) * scaleFactor,
-                  center[2] + (vertex[2] - center[2]) * scaleFactor,
-                ]
-                return scaledVertex.join(' ')
-              })
-              .join(', ')
-            const faceIndices = [...Array(face.length).keys(), -1].join(' ')
+  const geometryContent = useMemo(
+    () =>
+      faces
+        .map(face => {
+          const center = calculateFaceCenter(face)
+          const faceCoordinates = face
+            .map(vertexIndex => {
+              const vertex = vertices[vertexIndex]
+              const scaledVertex = [
+                center[0] + (vertex[0] - center[0]) * scaleFactor,
+                center[1] + (vertex[1] - center[1]) * scaleFactor,
+                center[2] + (vertex[2] - center[2]) * scaleFactor,
+              ]
+              return scaledVertex.join(' ')
+            })
+            .join(', ')
+          const faceIndices = [...Array(face.length).keys(), -1].join(' ')
 
-            return `
-            <shape>
-              <appearance>
-                <material emissivecolor="${foregroundColor}" diffusecolor="0 0 0"></material>
-              </appearance>
-              <indexedfaceset solid="true" coordindex="${faceIndices}">
-                <coordinate point="${faceCoordinates}"></coordinate>
-              </indexedfaceset>
-            </shape>
-          `
-          })
-          .join('')}
-      </scene>
-    </x3d>
-  `,
-    [
-      dimensions.width,
-      dimensions.height,
-      cameraDistance,
-      fieldOfView,
-      faces,
-      calculateFaceCenter,
-      vertices,
-      scaleFactor,
-      foregroundColor,
-    ],
+          return `
+          <shape>
+            <appearance>
+              <material emissivecolor="${foregroundColor}" diffusecolor="0 0 0"></material>
+            </appearance>
+            <indexedfaceset solid="true" coordindex="${faceIndices}">
+              <coordinate point="${faceCoordinates}"></coordinate>
+            </indexedfaceset>
+          </shape>
+        `
+        })
+        .join(''),
+    [faces, calculateFaceCenter, vertices, scaleFactor, foregroundColor],
   )
 
   useEffect(() => {
     if (!containerRef.current) return
 
-    containerRef.current.innerHTML = x3dContent
+    containerRef.current.innerHTML = `
+      <x3d style='width: 100%; height: 100%; display: block;'>
+        <scene>
+          <viewpoint id='camera' orientation='0 1 0 0'></viewpoint>
+          ${geometryContent}
+        </scene>
+      </x3d>
+    `
 
-    setTimeout(() => {
-      if (window.x3dom && typeof window.x3dom.reload === 'function') {
-        window.x3dom.reload()
-      }
-    }, 100)
-  }, [x3dContent, shapeName])
+    if (window.x3dom && typeof window.x3dom.reload === 'function') {
+      window.x3dom.reload()
+    }
+  }, [geometryContent, shapeName])
+
+  useEffect(() => {
+    const x3dEl = containerRef.current?.querySelector('x3d') as X3DElement | null
+    const viewpoint = x3dEl?.querySelector('#camera') as HTMLElement | null
+    if (x3dEl) {
+      x3dEl.setAttribute('width', `${dimensions.width}px`)
+      x3dEl.setAttribute('height', `${dimensions.height}px`)
+    }
+    if (viewpoint) {
+      viewpoint.setAttribute('position', `0 0 ${cameraDistance}`)
+      viewpoint.setAttribute('fieldOfView', `${fieldOfView}`)
+    }
+    if (x3dEl?.runtime && typeof x3dEl.runtime.resize === 'function') {
+      x3dEl.runtime.resize()
+    }
+  }, [dimensions, cameraDistance, fieldOfView])
 
   return (
     <div


### PR DESCRIPTION
## Summary
- resize X3D scene using runtime APIs instead of reloading on window change

## Testing
- `npm run lint`
- `npm run types`


------
https://chatgpt.com/codex/tasks/task_e_6858358998dc8321a229ca50e1987096