### PR TITLE
Add gap selector for shape viewer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:

--- a/src/app/[shape]/page.tsx
+++ b/src/app/[shape]/page.tsx
@@ -1,6 +1,5 @@
 import { getAllPolyhedronNames, getPolyhedronData } from '@/lib/polyhedra'
-import ShapeViewer from '@/components/shape-viewer'
-import ShapeSidebar from '@/components/shape-sidebar'
+import ShapePageClient from '@/components/shape-page-client'
 
 export const dynamicParams = false
 
@@ -24,16 +23,11 @@ export default async function PolyhedronPage({ params }: PageProps) {
   const shapes = await getAllPolyhedronNames()
 
   return (
-    <>
-      <ShapeSidebar shapes={shapes} />
-      <div className='w-full h-screen'>
-        <ShapeViewer
-          key={resolvedParams.shape}
-          shapeName={resolvedParams.shape}
-          vertices={data!.vertices}
-          faces={data!.faces}
-        />
-      </div>
-    </>
+    <ShapePageClient
+      shapeName={resolvedParams.shape}
+      vertices={data!.vertices}
+      faces={data!.faces}
+      shapes={shapes}
+    />
   )
 }

--- a/src/components/shape-page-client.tsx
+++ b/src/components/shape-page-client.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useState } from 'react'
+import ShapeSidebar from '@/components/shape-sidebar'
+import ShapeViewer from '@/components/shape-viewer'
+import { GAP_SIZE } from '@/lib/defaults'
+
+interface ShapePageClientProps {
+  shapeName: string
+  vertices: number[][]
+  faces: number[][]
+  shapes: string[]
+}
+
+export default function ShapePageClient({
+  shapeName,
+  vertices,
+  faces,
+  shapes,
+}: ShapePageClientProps) {
+  const [gap, setGap] = useState(GAP_SIZE)
+
+  return (
+    <>
+      <ShapeSidebar shapes={shapes} gap={gap} onGapChange={setGap} />
+      <div className='w-full h-screen'>
+        <ShapeViewer
+          key={shapeName}
+          shapeName={shapeName}
+          vertices={vertices}
+          faces={faces}
+          gapSize={gap}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/components/shape-sidebar.tsx
+++ b/src/components/shape-sidebar.tsx
@@ -11,9 +11,15 @@ import {
 
 interface ShapeSidebarProps {
   shapes: string[]
+  gap: number
+  onGapChange: (gap: number) => void
 }
 
-export default function ShapeSidebar({ shapes }: ShapeSidebarProps) {
+export default function ShapeSidebar({
+  shapes,
+  gap,
+  onGapChange,
+}: ShapeSidebarProps) {
   const router = useRouter()
   const params = useParams()
   const currentShape = params.shape as string
@@ -42,6 +48,18 @@ export default function ShapeSidebar({ shapes }: ShapeSidebarProps) {
           ))}
         </SelectContent>
       </Select>
+      <div className='mt-4'>
+        <Select value={gap.toString()} onValueChange={value => onGapChange(Number(value))}>
+          <SelectTrigger className='w-full'>
+            <SelectValue placeholder='Gap size'>{gap}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {Array.from({ length: 20 }, (_, i) => i + 1).map(value => (
+              <SelectItem key={value} value={value.toString()}>{value}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- add gap selector dropdown to the sidebar
- update sidebar to accept gap props
- create `ShapePageClient` to coordinate sidebar and viewer
- wire gap selector through page and viewer

## Testing
- `pnpm lint`
- `pnpm types`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68583bfcd02483219ff24ca1c63e8a71